### PR TITLE
Add support for non `#[derive]`-input items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cfg_eval"
-version = "0.1.0"
+version = "0.2.0-rc1"
 dependencies = [
  "cfg_eval",
  "macro_rules_attribute",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cfg_eval"
-version = "0.2.0-rc1"
+version = "0.1.2"
 dependencies = [
  "cfg_eval",
  "macro_rules_attribute",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "cfg_eval"
 version = "0.1.0"
 dependencies = [
+ "cfg_eval",
  "macro_rules_attribute",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "cfg_eval"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.1.0"
+version = "0.2.0-rc1"
 edition = "2021"
 rust-version = "1.61.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ docs-rs = [
     "better-docs",
 ]
 
+# Support for any kind of item, not only derive inputs.
+items = []
+
 [dependencies]
 proc-macro2.version = "1.0.0"
 quote.version = "1.0.0"
@@ -44,6 +47,8 @@ syn.features = [
 
 [dev-dependencies]
 macro_rules_attribute.version = "0.2.0"
+cfg_eval.path = "."
+cfg_eval.features = ["items"]
 
 [workspace]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "cfg_eval"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.2.0-rc1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.61.0"
 
@@ -37,7 +37,7 @@ items = []
 [dependencies]
 proc-macro2.version = "1.0.0"
 quote.version = "1.0.0"
-syn.version = "=2.0.0"
+syn.version = "2.0.0"
 syn.default-features = false
 syn.features = [
     "parsing",

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -22,4 +22,16 @@ fn main()
         #[cfg(any())]
         NonExistingVariant,
     }
+
+    #[cfg_eval]
+    #[apply(debugger)]
+    const _: () = {
+        enum _WithoutCfgEval {
+            #[cfg(any())]
+            NonExistingVariant,
+        }
+        #[cfg(all())] #[cfg_attr(all(), foo)] fn foo() {}
+        #[cfg(all())] { 42 }
+        #[cfg(any())] { 27 }
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,10 @@ use ::syn::{*,
 /// https://doc.rust-lang.org/1.70.0/core/prelude/v1/attr.cfg_eval.html)
 /// in stable Rust.
 ///
-///   - Note: this macro only works on `struct`, `enum`, and `union`
-///     definitions (_i.e._, on `#[derive]` input).
+///   - Note: this macro, by default, only works on `struct`, `enum`, and
+///     `union` definitions (_i.e._, on `#[derive]` input).
+///
+///     Enable `features = ["items"]` to get support for arbitary items.
 ///
 /// ## Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,11 +333,15 @@ fn cfg_eval_impl(
         ),
     ));
 
-    Ok(quote_spanned!(span=>
+    let attrs_to_add = quote_spanned!(span=>
         #[::core::prelude::v1::derive(
             #krate::ඞRemoveExterminate
         )]
         #[#krate::ඞdalek_exterminate]
+    );
+
+    Ok(quote_spanned!(Span::mixed_site()=>
+        #attrs_to_add
         #input
     ))
 }

--- a/tests/item.rs
+++ b/tests/item.rs
@@ -1,0 +1,57 @@
+macro_rules! stringify_rhs {(
+    const _: () = $value:tt ;
+) => (
+    stringify! $value
+)}
+
+macro_rules! cfg_eval_stringify {(
+    $($body:tt)*
+) => ({
+    #[::cfg_eval::cfg_eval]
+    #[::macro_rules_attribute::apply(stringify_rhs!)]
+    const _: () = { $($body)* };
+})}
+
+#[test]
+fn main()
+{
+    assert_eq!(
+        cfg_eval_stringify! {
+            enum _WithoutCfgEval {
+                #[cfg(any())]
+                NonExistingVariant,
+            }
+
+            #[cfg(all())]
+            #[cfg_attr(all(), foo)]
+            fn foo()
+            {}
+
+            cfg!(any());
+
+            #[cfg(all())] {
+                42
+            }
+
+            #[cfg(any())] {
+                27
+            }
+        },
+        stringify! {
+            enum _WithoutCfgEval {
+            }
+
+            #[cfg(all())] // <- Redundantly kept.
+            #[foo]
+            fn foo()
+            {}
+
+            // Not expanded.
+            cfg!(any());
+
+            #[cfg(all())] /* <- Redundantly kept. */ {
+                42
+            }
+        },
+    );
+}


### PR DESCRIPTION
The trick being to use the discriminant specifier of an `enum` as a channel through which to smuggle an arbitrary block, within which arbitrary items may occur.